### PR TITLE
feat: Use codermatch app URLs without prefix

### DIFF
--- a/codermatching/urls.py
+++ b/codermatching/urls.py
@@ -17,6 +17,6 @@ from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
-    path('codermatch/', include('codermatch.urls')),
+    path('', include('codermatch.urls')),
     path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
urls.py
- remove codermatch/ from path

reason:
That way the URLs from the codermatch app should be used normally.
So we don't need to call the domain-name like https://codermatching.herokuapp.com/codermatch/ to access the index, but we should be able to access it by calling https://codermatching.herokuapp.com/

fixes #1