### PR TITLE
include staticfiles directory of project in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ media
 # in your Git repository. Update and uncomment the following line accordingly.
 # <django-project-name>/staticfiles/
 # codermatching/static/ #excluded because of https://twitter.com/ChatDjango/status/1491202746003107841?s=20&t=q8uRU2iipcipWR7xIWhyag    and     https://twitter.com/ChatDjango/status/1491202921794781189?s=20&t=q8uRU2iipcipWR7xIWhyag
+codermatching/staticfiles/
 
 ### Django.Python Stack ###
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
**.gitignore**:
- include codermatching/staticfiles/

purpose:
- do not upload the staticfiles directory to GitHub
	- avoid exposure of static files (security) - does this make sense?
	- exclude staticfiles/ directory because `collectstatic` is part of the build process (as mentioned in the respective comment of the .gitignore file
> `# If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/`