### PR TITLE
move testHeroku branch to main again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ media
 # in your Git repository. Update and uncomment the following line accordingly.
 # <django-project-name>/staticfiles/
 # codermatching/static/ #excluded because of https://twitter.com/ChatDjango/status/1491202746003107841?s=20&t=q8uRU2iipcipWR7xIWhyag    and     https://twitter.com/ChatDjango/status/1491202921794781189?s=20&t=q8uRU2iipcipWR7xIWhyag
+codermatching/staticfiles/
 
 ### Django.Python Stack ###
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
`git log --oneline --graph --all` currently looks like this:
```
C:\Users\Name\codingprojects\CoderMatching\codermatching (localDeploy)
(venv) λ git log --oneline --graph --all
* 93b3589 (HEAD -> localDeploy, origin/main, testHeroku, main) include staticfiles directory of project in gitignore *   6f58621 Merge pull request #2 from Sammeeey/testHeroku
|\
| * 94ff982 (testHeroku/main, origin/testHeroku) feat: Use codermatch app URLs without prefix
|/
* 8050bd3 (production/master, production/main) fix: remove remaining slashes from beginning of static template tag path's
```
- trying to move `origin/testHeroku` to HEAD