### PR TITLE
fix #9: make gitignore file ignore staticfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ media
 # in your Git repository. Update and uncomment the following line accordingly.
 # <django-project-name>/staticfiles/
 # codermatching/static/ #excluded because of https://twitter.com/ChatDjango/status/1491202746003107841?s=20&t=q8uRU2iipcipWR7xIWhyag    and     https://twitter.com/ChatDjango/status/1491202921794781189?s=20&t=q8uRU2iipcipWR7xIWhyag
-codermatching/staticfiles/
+staticfiles/
 
 ### Django.Python Stack ###
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
- remove *codermatching/* prefix in .gitignore file to actually ignore the staticfiles directory in the root directory of the project
- fixes #9 